### PR TITLE
New variable to enable waiting for contracts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     - 8545:8545
     networks:
     - backend
+    environment:
+      LOCAL_CONTRACTS: 'true'
     volumes:
     - artifacts:/keeper-contracts/artifacts/
 
@@ -31,6 +33,7 @@ services:
     environment:
       KEEPER_HOST: http://keeper-contracts
       DB_HOSTNAME: mongodb
+      LOCAL_CONTRACTS: 'true'
     volumes:
     - artifacts:/usr/local/keeper-contracts/:ro
 
@@ -43,6 +46,7 @@ services:
     environment:
       KEEPER_HOST: keeper-contracts
       OCEAN_HOST: provider
+      LOCAL_CONTRACTS: 'true'
     volumes:
     - artifacts:/pleuston/node_modules/@oceanprotocol/keeper-contracts/artifacts/:ro
 


### PR DESCRIPTION
## Description

Included the variable `$LOCAL_CONTRACTS`. If it is equal to "true", it will wait for the file `/usr/local/keeper-contracts/ready` to exists before starting. In other case it will start directly.

## Is this PR related with an open issue?

Related to Issue oceanprotocol/docker-images#25

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()