### PR TITLE
put back project name on docker-compose commands

### DIFF
--- a/start_ocean.sh
+++ b/start_ocean.sh
@@ -10,17 +10,16 @@ export REUSE_DATABASE="false"
 export KEEPER_NETWORK_NAME="ganache"
 export ARTIFACTS_FOLDER=~/.ocean/keeper-contracts/artifacts
 
-if [ "$1" == "--no-pleuston" ]
-then
-export REUSE_DATABASE="true"
-docker-compose -f docker-compose-no-pleuston.yml up
+if [ "$1" == "--no-pleuston" ]; then
 
-elif [ "$1" == "--local-parity-node" ]
-then
-export KEEPER_NETWORK_NAME="ocean_poa_net_local"
-docker-compose -f docker-compose-local-parity-node.yml up
+    export REUSE_DATABASE="true"
+    docker-compose --project-name=ocean -f docker-compose-no-pleuston.yml up
+
+elif [ "$1" == "--local-parity-node" ]; then
+
+    export KEEPER_NETWORK_NAME="ocean_poa_net_local"
+    docker-compose --project-name=ocean -f docker-compose-local-parity-node.yml up
 
 else
-docker-compose up
-
+    docker-compose --project-name=ocean up
 fi


### PR DESCRIPTION
Adds back `--project-name=ocean` to all `docker-compose` commands and some general bash statement formatting.