### PR TITLE
moved reuse_database to own switch

### DIFF
--- a/start_ocean.sh
+++ b/start_ocean.sh
@@ -38,8 +38,10 @@ while :; do
             export OCEAN_VERSION=latest
             printf $COLOR_Y'Switched to latest components...\n\n'$COLOR_RESET
             ;;
-        --no-pleuston)
+        --reuse-database)
             export REUSE_DATABASE="true"
+            ;;
+        --no-pleuston)
             COMPOSE_FILE='docker-compose-no-pleuston.yml'
             printf $COLOR_Y'Starting without Pleuston...\n\n'$COLOR_RESET
             ;;


### PR DESCRIPTION
## Description

i want to be able to use `--no-pleuston` without keeping the db. New command is now `--no-pleuston --reuse-database` to achieve the same functionality.