### PR TITLE
Include default environment file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,11 @@
+# Must be set to true for the first run, change it to "false" to avoid migrating the smart contracts on each run.
+DEPLOY_CONTRACTS=true
+# Ganache specific option, these two options have no effect when not running ganache-cli
+GANACHE_DATABASE_PATH=.
+REUSE_DATABASE=false
+# Specify which ethereum client to run or connect to: kovan, ganache, or ocean_poa_net_local
+KEEPER_NETWORK_NAME=ganache
+ARTIFACTS_FOLDER=~/.ocean/keeper-contracts/artifacts
+# Specify which ocean version use: stable, latests, ...
+OCEAN_VERSION=stable
+COMPOSE_FILE=docker-compose.yml

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The Ocean Docker compose starts the following components:
 
 ### Environment Variables
 
-The `start_ocean.sh` script sets defaults for the following environment variables but you can use these in combination with the Docker Compose files for further customization, e.g.:
+The `start_ocean.sh` script and `.env` file sets defaults for the following environment variables but you can use these in combination with the Docker Compose files for further customization, e.g.:
 
 ```bash
 export REUSE_DATABASE="true"


### PR DESCRIPTION
## Description

Includes a default `.env` variable to load the needed environment variables to run `docker-compose up`.

## Is this PR related with an open issue?

Related to Issue #29 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()