### PR TITLE
secret store api cors proxy

### DIFF
--- a/cors-proxy.conf
+++ b/cors-proxy.conf
@@ -1,0 +1,29 @@
+events {}
+http {
+  upstream ss {
+    server secret-store:12001;
+  }
+  server {
+    listen 12001;
+    location ~ ^/ {
+      if ($request_method = 'OPTIONS') {
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow_Credentials' 'true';
+        add_header 'Access-Control-Allow-Headers' 'Origin, X-Requested-With, Content-Type, Accept';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        add_header 'Content-Type' 'text/plain; charset=utf-8';
+        add_header 'Content-Length' 0;
+        return 204;
+      }
+      add_header 'Access-Control-Allow-Origin' '*';
+      add_header 'Access-Control-Allow_Credentials' 'true';
+      add_header 'Access-Control-Allow-Headers' 'Origin, X-Requested-With, Content-Type, Accept';
+      add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+      proxy_pass http://ss;
+      proxy_redirect     off;
+      proxy_set_header   Origin "";
+    }
+    access_log off;
+    error_log off;
+  }
+}

--- a/docker-compose-local-parity-node.yml
+++ b/docker-compose-local-parity-node.yml
@@ -53,10 +53,23 @@ services:
     - ./parity/secret_store/keys/:/parity_data/keys/ocean-network/
     ports:
     - 12000:12000
-    - 12001:12001
+    - 12001
     networks:
       backend:
         ipv4_address: 172.15.0.13
+
+  secret-store-cors-proxy:
+    image: nginx:alpine
+    volumes:
+      - ./cors-proxy.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - secret-store
+    ports:
+      - 12001:12001
+    networks:
+      backend:
+        ipv4_address: 172.15.0.16
+    command: nginx -g 'daemon off;'
 
   keeper-contracts:
     image: oceanprotocol/keeper-contracts:${OCEAN_VERSION:-stable}


### PR DESCRIPTION
## Description

Allows Pleuston to use local secret store node by proxying and adding CORS headers.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![](https://media.giphy.com/media/OI8TsOa9KFAPu/giphy.gif)