### PR TITLE
Add link to Azure Storage tutorial in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ You need to have the newest versions available of both:
 * [Docker](https://www.docker.com/get-started)
 * [Docker Compose](https://docs.docker.com/compose/)
 
-Populate the following in `brizo.env` file:
-* All of the `AZURE_`... related variables: necessary for `Brizo` to serve consume requests
+Populate the following in the `brizo.env` file:
+
+* All of the `AZURE_`... related variables: necessary for `Brizo` to serve consume requests. You will get the values if you go through the [Azure Storage tutorial in the Ocean Protocol docs](https://docs.oceanprotocol.com/tutorials/azure-for-brizo/).
 
 ## Get Started
 


### PR DESCRIPTION
There's now a tutorial about how to set up Azure Storage so I added a link to that (to help users get the values of all the `AZURE_`... settings.